### PR TITLE
docs: Use https:// before ngrok.com

### DIFF
--- a/docs/content/en/options.md
+++ b/docs/content/en/options.md
@@ -8,7 +8,7 @@ position: 2
 
 ## Adding an authtoken
 
-You can create a basic http-https-tcp tunnel without an authtoken. For custom subdomains and more you should obtain an authtoken by signing up at [ngrok.com](ngrok.com).
+You can create a basic http-https-tcp tunnel without an authtoken. For custom subdomains and more you should obtain an authtoken by signing up at [ngrok.com](https://ngrok.com).
 
 Once you have your token you can add it to your `.env` file with the key `NGROK_AUTHTOKEN`.
 


### PR DESCRIPTION
This way it is not a relative link anymore