### PR TITLE
Make options.addr available

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -43,7 +43,12 @@ const nuxtModule: Module<ModuleOptions> = function(moduleOptions) {
       await ngrok.authtoken(options.authtoken)
     }
 
-    url = await ngrok.connect({ ...options, addr: port } as INgrokOptions)
+    let addr = port
+    if(options.addr){
+      addr = options.addr
+    }
+
+    url = await ngrok.connect({ ...options, addr } as INgrokOptions)
 
     nuxt.options.publicRuntimeConfig.ngrok = { url }
     nuxt.options.cli.badgeMessages.push(


### PR DESCRIPTION
Little fix to give the possibility to set the options.addr. Currently it will be overwritten by the port number.
```
ngrok: {
    addr: 'https://localhost:3000',
 },
```

If you use a ssl on localhost you need to set a url for ngrok.connect instead of the port only. Else you receive an 3004 error.
https://stackoverflow.com/questions/68459491/how-do-i-fix-ngrok-invalid-http-response-error

```
server: {
    host: 0,
    port: 3000,
    https: {
      key: fs.readFileSync(path.resolve(__dirname, 'server.key')),
      cert: fs.readFileSync(path.resolve(__dirname, 'server.crt')),
    },
  },
```